### PR TITLE
multi-architecture implementation

### DIFF
--- a/1.14.4/x86_64-bionic/Dockerfile
+++ b/1.14.4/x86_64-bionic/Dockerfile
@@ -2,7 +2,7 @@ FROM ubuntu:bionic
 
 # To improve : static hash make dynamic build of versions impossible.
 ARG VERSION=1.14.4
-ARG VERSION_HASH=6266235abe4bcbd41ea57bdf42f11ef89aa69f0386e8c8846d5228af69e7fa13
+ARG TARGETPLATFORM
 
 ENV USER=dogecoin
 ENV DATADIR=/${USER}/.dogecoin
@@ -19,23 +19,28 @@ RUN apt update && apt install -y \
     wget \
     && rm -rf /var/lib/apt/lists/*
 
-# Download Dogecoin Core from github releases.
+# Download Dogecoin Core from github releases,
+# manage binary architecture using buildx & TARGETPLATFORM.
+WORKDIR /tmp
+
+RUN set -ex && \
+    if [ "${TARGETPLATFORM}" = "linux/amd64" ]; then TARGETPLATFORM=x86_64-linux-gnu; fi \
+    && if [ "${TARGETPLATFORM}" = "linux/arm64" ]; then TARGETPLATFORM=aarch64-linux-gnu; fi \
+    && if [ "${TARGETPLATFORM}" = "linux/arm/v7" ]; then TARGETPLATFORM=arm-linux-gnueabihf; fi \
+    && if [ "${TARGETPLATFORM}" = "linux/386" ]; then TARGETPLATFORM=i686-pc-linux-gnu; fi \
+    && wget https://github.com/dogecoin/dogecoin/releases/download/v${VERSION}/dogecoin-${VERSION}-${TARGETPLATFORM}.tar.gz
+
 # Move downloaded binaries and man pages in the container system.
-# Setuid on binaries with $USER rights, to limit root usage.
-#
-# Security: more secure way than check hash for download,
-# see https://github.com/docker-library/official-images#security
-RUN cd /tmp && \
-    wget https://github.com/dogecoin/dogecoin/releases/download/v${VERSION}/dogecoin-${VERSION}-x86_64-linux-gnu.tar.gz && \
-    echo "${VERSION_HASH} dogecoin-${VERSION}-x86_64-linux-gnu.tar.gz" | sha256sum -c && \
-    tar -xvf dogecoin-${VERSION}-x86_64-linux-gnu.tar.gz --strip-components=1 && \
+# Setuid on binaries with $USER rights, to prevent
+# root right with `docker exec`.
+RUN tar -xvf dogecoin-${VERSION}-*.tar.gz --strip-components=1 && \
     cp share/man/man1/*.1 /usr/share/man/man1 && \
     cp bin/dogecoin* /usr/local/bin && \
     chown ${USER}:${USER} /usr/local/bin/dogecoin* && \
     chmod 4555 /usr/local/bin/dogecoin* && \
     rm -rf /tmp/*
 
-COPY docker-entrypoint.py /usr/local/bin/docker-entrypoint
+COPY --chmod=555 docker-entrypoint.py /usr/local/bin/docker-entrypoint
 
 WORKDIR ${HOME}
 

--- a/1.14.4/x86_64-bionic/Dockerfile
+++ b/1.14.4/x86_64-bionic/Dockerfile
@@ -2,7 +2,6 @@ FROM ubuntu:bionic
 
 # To improve : static hash make dynamic build of versions impossible.
 ARG VERSION=1.14.4
-ARG TARGETPLATFORM
 
 ENV USER=dogecoin
 ENV DATADIR=/${USER}/.dogecoin
@@ -19,16 +18,15 @@ RUN apt update && apt install -y \
     wget \
     && rm -rf /var/lib/apt/lists/*
 
-# Download Dogecoin Core from github releases,
-# manage binary architecture using buildx & TARGETPLATFORM.
+# Download Dogecoin Core from github releases for cross-architecture
 WORKDIR /tmp
 
-RUN set -ex && \
-    if [ "${TARGETPLATFORM}" = "linux/amd64" ]; then TARGETPLATFORM=x86_64-linux-gnu; fi \
-    && if [ "${TARGETPLATFORM}" = "linux/arm64" ]; then TARGETPLATFORM=aarch64-linux-gnu; fi \
-    && if [ "${TARGETPLATFORM}" = "linux/arm/v7" ]; then TARGETPLATFORM=arm-linux-gnueabihf; fi \
-    && if [ "${TARGETPLATFORM}" = "linux/386" ]; then TARGETPLATFORM=i686-pc-linux-gnu; fi \
-    && wget https://github.com/dogecoin/dogecoin/releases/download/v${VERSION}/dogecoin-${VERSION}-${TARGETPLATFORM}.tar.gz
+RUN set -ex && ARCHITECTURE=$(dpkg --print-architecture) && \
+    if [ "${ARCHITECTURE}" = "amd64" ]; then ARCHITECTURE=x86_64-linux-gnu; fi \
+    && if [ "${ARCHITECTURE}" = "arm64" ]; then ARCHITECTURE=aarch64-linux-gnu; fi \
+    && if [ "${ARCHITECTURE}" = "armhf" ]; then ARCHITECTURE=arm-linux-gnueabihf; fi \
+    && if [ "${ARCHITECTURE}" = "i386" ]; then ARCHITECTURE=i686-pc-linux-gnu; fi \
+    && wget https://github.com/dogecoin/dogecoin/releases/download/v${VERSION}/dogecoin-${VERSION}-${ARCHITECTURE}.tar.gz
 
 # Move downloaded binaries and man pages in the container system.
 # Setuid on binaries with $USER rights, to prevent
@@ -40,7 +38,8 @@ RUN tar -xvf dogecoin-${VERSION}-*.tar.gz --strip-components=1 && \
     chmod 4555 /usr/local/bin/dogecoin* && \
     rm -rf /tmp/*
 
-COPY --chmod=500 docker-entrypoint.py /usr/local/bin/docker-entrypoint
+COPY docker-entrypoint.py /usr/local/bin/docker-entrypoint
+RUN chmod 500 /usr/local/bin/docker-entrypoint
 
 WORKDIR ${HOME}
 

--- a/1.14.4/x86_64-bionic/Dockerfile
+++ b/1.14.4/x86_64-bionic/Dockerfile
@@ -40,7 +40,7 @@ RUN tar -xvf dogecoin-${VERSION}-*.tar.gz --strip-components=1 && \
     chmod 4555 /usr/local/bin/dogecoin* && \
     rm -rf /tmp/*
 
-COPY --chmod=555 docker-entrypoint.py /usr/local/bin/docker-entrypoint
+COPY --chmod=500 docker-entrypoint.py /usr/local/bin/docker-entrypoint
 
 WORKDIR ${HOME}
 


### PR DESCRIPTION
fix https://github.com/dogecoin/docker/issues/17.

Beginning of an implementation for multi-architecture support using `buildx`. Remove security check, to rely on #6.

I'm able to build images for those for architecture : `amd64`, `arm64`, `armv7` & `i386`.
[Here](https://hub.docker.com/r/abcsxyz/dogecoin/tags) for Docker hub example.

It may be possible to use `dpkg` or `TARGETPLATFORM` to find architectures. It seems to me that `TARGETPLATFORM` is easier to use with `buildx`, but won't work if used directly with `docker build`.
`dpkg` would need few more operations (install of `dpkg-dev`, set manually variables before a dirtier mapping), but would work with `docker build`. Docker official images are using `dpkg`.

This version is cleaner for pushing to Docker Hub, but may be interesting to let the user use the image manually using `dpkg`. Any opinion ?

*It's using Github Action with configuration defined in #15 to publish image on Docker Hub*