### PR TITLE
create Github Action for Docker Hub

### DIFF
--- a/.github/workflows/docker-hub-publisher.yml
+++ b/.github/workflows/docker-hub-publisher.yml
@@ -1,0 +1,28 @@
+name: Docker Hub Publication
+on: [push]
+jobs:
+  Publish-Docker-Images:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository sources
+        uses: actions/checkout@v2
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKERHUB_USER }}
+          password: ${{ secrets.DOCKERHUB_PASSWORD }}
+
+      - name: Publish Docker image
+        uses: docker/build-push-action@v2
+        with:
+          context: 1.14.4/x86_64-bionic
+          platforms: linux/amd64,linux/arm64,linux/arm/v7,linux/386
+          push: true
+          tags: dogecoin/dogecoin:1.14.4


### PR DESCRIPTION
Following PR #14 for multi architecture support, this is a draft for a GitHub Action configuration, to publish images on Docker Hub using `buildx`.

Use `DOCKERHUB_USER` & `DOCKERHUB_PASSWORD` as GitHub Action secrets.

Work in progress to define the strategy to adopt, I will probably depend on an eventual script to generate new images and maybe on how it can be integrated on Github action of Dogecoin Core repository (on tag release ?). It's configured to publish only a single version for a single Dockerfile.

Need to figure out how to deal with new releases & update of Dockerfile (templates ?) to perform actions.