### PR TITLE
Enable arbitrary shell commands for entrypoint

### DIFF
--- a/1.14.4/x86_64-bionic/Dockerfile
+++ b/1.14.4/x86_64-bionic/Dockerfile
@@ -48,3 +48,4 @@ EXPOSE 22555 44555 18332
 VOLUME ["/dogecoin/.dogecoin"]
 
 ENTRYPOINT ["docker-entrypoint"]
+CMD ["dogecoind"]

--- a/1.14.4/x86_64-bionic/docker-entrypoint.py
+++ b/1.14.4/x86_64-bionic/docker-entrypoint.py
@@ -131,7 +131,10 @@ def run_executable(executable, executable_args):
     execute(executable, executable_args)
 
 if __name__ == "__main__":
-    executable = sys.argv.pop(1)
+    if sys.argv[1].startswith("-"):
+        executable = "dogecoind"
+    else:
+        executable = sys.argv.pop(1)
 
     #Container running arbitrary commands unrelated to dogecoin
     if executable not in CLI_EXECUTABLES:

--- a/1.14.4/x86_64-bionic/docker-entrypoint.py
+++ b/1.14.4/x86_64-bionic/docker-entrypoint.py
@@ -15,7 +15,7 @@ CLI_EXECUTABLES = [
         "dogecoin-tx",
         ]
 
-def execute(exectuable, args):
+def execute(executable, args):
     """
     Run container command with execve(2). Use manually execve
     to run the process as same pid and avoid to fork a child.


### PR DESCRIPTION
*Fix https://github.com/dogecoin/docker/issues/18*

Enable to launch arbitrary shell commands using `docker run`, like `docker run -it [image] bash`.

Following recommendation from [official docker images](https://github.com/docker-library/official-images#consistency):

> All official images should provide a consistent interface. A beginning user should be able to docker run official-image bash (or sh) without needing to learn about --entrypoint. It is also nice for advanced users to take advantage of entrypoint, so that they can docker run official-image --arg1 --arg2 without having to specify the binary to execute.