### PR TITLE
Fix pylint suggestions

### DIFF
--- a/1.14.5/bullseye/entrypoint.py
+++ b/1.14.5/bullseye/entrypoint.py
@@ -1,5 +1,7 @@
 #!/usr/bin/env python3
-
+"""
+  Docker entrypoint for Dogecoin Core
+"""
 import argparse
 import os
 import pwd
@@ -23,7 +25,8 @@ def execute(executable, args):
     executable_path = shutil.which(executable)
 
     if executable_path is None:
-        exit(f"{sys.argv[0]}: {executable} not found.")
+        print(f"{sys.argv[0]}: {executable} not found.")
+        sys.exit(1)
 
     #Prepare execve args & launch container command
     execve_args = [executable_path] + args
@@ -47,7 +50,7 @@ def executable_options(executable):
     man_folder = "/usr/share/man/man1"
     man_file = os.path.join(man_folder, f"{executable}.1")
 
-    with open(man_file, "r") as man_filestream:
+    with open(man_file, "r", encoding="utf-8") as man_filestream:
         man_content = man_filestream.read()
 
     # Regex to match single option entry in man(1) page
@@ -77,7 +80,7 @@ def create_datadir():
     os.makedirs(datadir, exist_ok=True)
 
     user = os.environ["USER"]
-    subprocess.run(["chown", "-R", f"{user}:{user}", datadir])
+    subprocess.run(["chown", "-R", f"{user}:{user}", datadir], check=True)
 
 def convert_env(executable):
     """
@@ -131,6 +134,9 @@ def run_executable(executable, executable_args):
     execute(executable, executable_args)
 
 def main():
+    """
+    Main routine
+    """
     if sys.argv[1].startswith("-"):
         executable = "dogecoind"
     else:

--- a/1.14.5/bullseye/entrypoint.py
+++ b/1.14.5/bullseye/entrypoint.py
@@ -25,7 +25,7 @@ def execute(executable, args):
     executable_path = shutil.which(executable)
 
     if executable_path is None:
-        print(f"{sys.argv[0]}: {executable} not found.")
+        print(f"{sys.argv[0]}: {executable} not found.", file=sys.stderr)
         sys.exit(1)
 
     #Prepare execve args & launch container command


### PR DESCRIPTION
In preparation of having automated linters, I ran [pylint](https://pylint.org) manually to fix any existing issues, so that we have a clean starting slate once I PR linters. Some issues I originally worked on have already been solved with #26 so I am working on top of that and making that blocking for this PR.

**Fixes:**

- [C0114](https://vald-phoenix.github.io/pylint-errors/plerr/errors/basic/C0114.html): Missing module docstring -> fixed by adding the docstring at the top of the `entrypoint.py` file
- [C0116](https://vald-phoenix.github.io/pylint-errors/plerr/errors/basic/C0116.html): Missing function or method docstring, in `main()` -> fixed by adding a docstring 🤓
- [W1514/PEP-0598](https://www.python.org/dev/peps/pep-0597/): Using open without explicitly specifying an encoding, in `executable_options()` -> fixed by specifying the manpage encoding as UTF-8
- [W1510](https://vald-phoenix.github.io/pylint-errors/plerr/errors/stdlib/W1510.html): Using subprocess.run without explicitly set `check`, in `create_datadir()` -> fixed by adding check=True argument
- [R1722](https://vald-phoenix.github.io/pylint-errors/plerr/errors/refactoring/R1722.html): Consider using sys.exit() (in `execute()` -> fixed by separating print from exit, and using sys.exit(1). Although this is just a recommendation, I think it's good to just follow the recommendations - saves time having to argue 😁