### PR TITLE
Optimize the build order to use cache better.

### DIFF
--- a/1.14.5/bullseye/Dockerfile
+++ b/1.14.5/bullseye/Dockerfile
@@ -2,35 +2,27 @@ FROM debian:bullseye-slim AS verify
 
 WORKDIR /verify
 
+# github repository locations
+ARG REPO_GITIAN_BUILDER=https://github.com/devrandom/gitian-builder.git
+ARG REPO_GITIAN_SIGS=https://github.com/dogecoin/gitian.sigs.git
+ARG REPO_DOGECOIN_CORE=https://github.com/dogecoin/dogecoin.git
+
 # Specify release variables
 ARG RLS_VERSION=1.14.5
 ARG RLS_OS=linux
 ARG RLS_LIB=gnu
 ARG RLS_ARCH=
 
-# Automatically detect architecture
-RUN set -ex && ARCHITECTURE=$(dpkg --print-architecture) \
-    && if [ "${ARCHITECTURE}" = "amd64" ]; then RLS_ARCH=x86_64 ; fi \
-    && if [ "${ARCHITECTURE}" = "arm64" ]; then RLS_ARCH=aarch64; fi \
-    && if [ "${ARCHITECTURE}" = "armhf" ]; then RLS_ARCH=arm && RLS_LIB=gnueabihf; fi \
-    && if [ "${ARCHITECTURE}" = "i386" ]; then RLS_ARCH=i686-pc; fi \
-    && if [ "${RLS_ARCH}" = "" ]; then echo "Could not determine architecture" >&2; exit 1; fi \
-    && RLS_FILE_NAME=dogecoin-${RLS_VERSION}-${RLS_ARCH}-${RLS_OS}-${RLS_LIB}.tar.gz \
-    && echo -n ${RLS_FILE_NAME} > .filename
-
-ARG SIG_PATH=${RLS_VERSION}-${RLS_OS}
-ARG DESCRIPTOR_PATH=dogecoin/contrib/gitian-descriptors/gitian-${RLS_OS}.yml
-
-ARG RLS_LOCATION=https://github.com/dogecoin/dogecoin/releases/download/v${RLS_VERSION}
-ARG REPO_GITIAN_BUILDER=https://github.com/devrandom/gitian-builder.git
-ARG REPO_GITIAN_SIGS=https://github.com/dogecoin/gitian.sigs.git
-ARG REPO_DOGECOIN_CORE=https://github.com/dogecoin/dogecoin.git
-
-# Pinned known sha256sums
+# pin known sha256sums
 RUN    echo f3bc387f393a0d55b6f653aef24febef6cb6f352fab2cbb0bae420bddcdacd1c  dogecoin-1.14.5-aarch64-linux-gnu.tar.gz > SHASUMS \
     && echo dfdcdc6bb36076e7634cc8ed89138ec0383d73ba42b3e7ecfa9279b8949bce6b  dogecoin-1.14.5-arm-linux-gnueabihf.tar.gz >> SHASUMS \
     && echo 7e7dd731ecfb2b78d6cc50d013ebf5faceeab50c59ffa2ab7551167b1bb81f08  dogecoin-1.14.5-i686-pc-linux-gnu.tar.gz >> SHASUMS \
     && echo 17a03f019168ec5283947ea6fbf1a073c1d185ea9edacc2b91f360e1c191428e  dogecoin-1.14.5-x86_64-linux-gnu.tar.gz >> SHASUMS
+
+# static derived variables
+ARG SIG_PATH=${RLS_VERSION}-${RLS_OS}
+ARG DESCRIPTOR_PATH=dogecoin/contrib/gitian-descriptors/gitian-${RLS_OS}.yml
+ARG RLS_LOCATION=https://github.com/dogecoin/dogecoin/releases/download/v${RLS_VERSION}
 
 # install system requirements
 RUN apt update && apt install -y \
@@ -46,8 +38,15 @@ RUN git clone --depth 1 ${REPO_GITIAN_BUILDER} gitian \
     && git clone --depth 1 -b v${RLS_VERSION} ${REPO_DOGECOIN_CORE} dogecoin \
     && find dogecoin/contrib/gitian-keys -name "*.pgp" |xargs -n 1 gpg --import
 
-# download release binary and verify against random OK signer and pinned shasums
-RUN RLS_FILE_NAME=$(cat .filename) \
+# determine architecture, download release binary
+# and verify against random OK signer and pinned shasums
+RUN set -ex && ARCHITECTURE=$(dpkg --print-architecture) \
+    && if [ "${ARCHITECTURE}" = "amd64" ]; then RLS_ARCH=x86_64 ; fi \
+    && if [ "${ARCHITECTURE}" = "arm64" ]; then RLS_ARCH=aarch64; fi \
+    && if [ "${ARCHITECTURE}" = "armhf" ]; then RLS_ARCH=arm && RLS_LIB=gnueabihf; fi \
+    && if [ "${ARCHITECTURE}" = "i386" ]; then RLS_ARCH=i686-pc; fi \
+    && if [ "${RLS_ARCH}" = "" ]; then echo "Could not determine architecture" >&2; exit 1; fi \
+    && RLS_FILE_NAME=dogecoin-${RLS_VERSION}-${RLS_ARCH}-${RLS_OS}-${RLS_LIB}.tar.gz \
     && wget ${RLS_LOCATION}/${RLS_FILE_NAME} \
     && gitian/bin/gverify --no-markup -d sigs -r ${SIG_PATH} ${DESCRIPTOR_PATH} \
        | grep OK | shuf -n 1 | sed s/:.*// > random_signer.txt \
@@ -65,11 +64,6 @@ ENV HOME=/${USER}
 
 RUN useradd ${USER} --home-dir ${HOME}
 
-# Dependencies install
-RUN apt update && apt install -y \
-    python3 \
-    && rm -rf /var/lib/apt/lists/*
-
 WORKDIR /tmp
 
 # Copy the downloaded binary from the verify stage
@@ -84,9 +78,6 @@ RUN tar -xvf dogecoin.tar.gz --strip-components=1 \
     && chmod 4555 /usr/local/bin/dogecoin* \
     && rm -rf *
 
-COPY entrypoint.py /usr/local/bin/entrypoint.py
-RUN chmod 500 /usr/local/bin/entrypoint.py
-
 WORKDIR ${HOME}
 
 # P2P network (mainnet, testnet & regnet respectively)
@@ -96,6 +87,14 @@ EXPOSE 22556 44556 18444
 EXPOSE 22555 44555 18332
 
 VOLUME ["/dogecoin/.dogecoin"]
+
+# Dependencies install
+RUN apt update && apt install -y \
+    python3 \
+    && rm -rf /var/lib/apt/lists/*
+
+COPY entrypoint.py /usr/local/bin/entrypoint.py
+RUN chmod 500 /usr/local/bin/entrypoint.py
 
 ENTRYPOINT ["entrypoint.py"]
 CMD ["dogecoind"]


### PR DESCRIPTION
Partially implements #22

Verify:
- Put static(ish) repository locations at the top because those do not change often
- Move shasum pins to be right after version/variant declaration because they change when those change
- Merge architecture detection into the verification step to save an execution step and remove the build environment portability hack

Final:
- install python as late as possible, before copying entrypoint to stay more developer friendly for now. May need to be changed from a security perspective.
- move the entrypoint inclusion as far down the process as we can