### PR TITLE
refactor: removed dogecoin-qt

### DIFF
--- a/1.14.5/bullseye/Dockerfile
+++ b/1.14.5/bullseye/Dockerfile
@@ -72,8 +72,7 @@ COPY --from=verify /verify/dogecoin.tar.gz ./
 # Move downloaded binaries and man pages in the container system.
 # Setuid on binaries with $USER rights, to limit root usage.
 RUN tar -xvf dogecoin.tar.gz --strip-components=1 \
-    && cp share/man/man1/*.1 /usr/share/man/man1 \
-    && cp bin/dogecoin* /usr/local/bin \
+    && cp bin/dogecoind bin/dogecoin-cli bin/dogecoin-tx /usr/local/bin/ \
     && chown ${USER}:${USER} /usr/local/bin/dogecoin* \
     && chmod 4555 /usr/local/bin/dogecoin* \
     && rm -rf *

--- a/1.14.5/bullseye/entrypoint.py
+++ b/1.14.5/bullseye/entrypoint.py
@@ -11,7 +11,6 @@ import subprocess
 
 CLI_EXECUTABLES = [
         "dogecoind",
-        "dogecoin-qt",
         "dogecoin-cli",
         "dogecoin-tx",
         ]
@@ -53,7 +52,7 @@ def executable_options(executable):
     command_arguments = [executable, "-help"]
 
     #`-help-debug` display extra flag in help menu for dogecoind & qt
-    if executable in ["dogecoind", "dogecoin-qt"]:
+    if executable == "dogecoind":
         command_arguments.append("-help-debug")
 
     help_options = get_help(command_arguments)
@@ -127,7 +126,7 @@ def run_executable(executable, executable_args):
     to manage a single process in a container & more predictive
     signal handling.
     """
-    if executable in ["dogecoind", "dogecoin-qt"]:
+    if executable == "dogecoind":
         executable_args.append("-printtoconsole")
 
     #Switch process from root to user.


### PR DESCRIPTION
removed dogecoin-qt from Dockerfile and entrypoint.py since it's not supported and wasting resources.

refined Dockerfile by extracting the specific files we need from our archive and copying each while setting appropriate permissions and owner:group in each COPY.

removed unnecessary WORKDIR /tmp since we are only copying specific files from verify build stage, thus we have nothing to rm -rf *

