### PR TITLE
Qa: add linters

### DIFF
--- a/.github/workflows/lint-js.yml
+++ b/.github/workflows/lint-js.yml
@@ -1,0 +1,29 @@
+name: lint-js
+
+on:
+  push:
+    paths:
+      - "**/*.js"
+      - ".github/workflows/lint-js.yml"
+  pull_request:
+    paths:
+      - "**/*.js"
+      - ".github/workflows/lint-js.yml"
+
+jobs:
+  lint-js:
+    name: lint (javascript)
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    strategy:
+      fail-fast: false
+    steps:
+      - name: Install semistandard
+        run: |
+          npm install -g semistandard
+
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Run linter
+        run: find . -name "*.js" | xargs semistandard

--- a/.github/workflows/lint-py.yml
+++ b/.github/workflows/lint-py.yml
@@ -1,0 +1,28 @@
+name: lint-py
+
+on:
+  push:
+    paths:
+      - "**/*.py"
+      - ".github/workflows/lint-py.yml"
+  pull_request:
+    paths:
+      - "**/*.py"
+      - ".github/workflows/lint-py.yml"
+
+jobs:
+  lint-py:
+    name: lint (python)
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    strategy:
+      fail-fast: false
+    steps:
+      - name: Install pylint
+        run: pip3 install pylint
+
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Run linter
+        run: find . -name "*.py" | xargs pylint


### PR DESCRIPTION
Implement `pylint` for python code and `semistandard` for javascript code.

- Each linter only triggers if a PR changes a relevant file or the linter flow.
- Linters run on push too, because those could help stopping an automated build later.

Blocked by #32 