### PR TITLE
refactor: mod cp tar.gz using buildx for leaner builds

### DIFF
--- a/1.14.5/bullseye/Dockerfile
+++ b/1.14.5/bullseye/Dockerfile
@@ -53,7 +53,10 @@ RUN RLS_FILE_NAME=$(cat .filename) \
        | grep OK | shuf -n 1 | sed s/:.*// > random_signer.txt \
     && grep ${RLS_FILE_NAME} sigs/${SIG_PATH}/$(cat random_signer.txt)/*assert | sha256sum -c \
     && grep ${RLS_FILE_NAME} SHASUMS | sha256sum -c \
-    && mv ${RLS_FILE_NAME} dogecoin.tar.gz
+    && tar -xzf ${RLS_FILE_NAME} \
+    --wildcards "*/dogecoin*" \
+    --strip-components=1 \
+    --one-top-level=dogecoin
 
 FROM debian:bullseye-slim AS final
 
@@ -70,24 +73,14 @@ RUN apt update && apt install -y \
     python3 \
     && rm -rf /var/lib/apt/lists/*
 
-WORKDIR /tmp
-
-# Copy the downloaded binary from the verify stage
-COPY --from=verify /verify/dogecoin.tar.gz ./
-
-# Move downloaded binaries and man pages in the container system.
-# Setuid on binaries with $USER rights, to limit root usage.
-RUN tar -xvf dogecoin.tar.gz --strip-components=1 \
-    && cp share/man/man1/*.1 /usr/share/man/man1 \
-    && cp bin/dogecoin* /usr/local/bin \
-    && chown ${USER}:${USER} /usr/local/bin/dogecoin* \
-    && chmod 4555 /usr/local/bin/dogecoin* \
-    && rm -rf *
-
-COPY entrypoint.py /usr/local/bin/entrypoint.py
-RUN chmod 500 /usr/local/bin/entrypoint.py
-
 WORKDIR ${HOME}
+# Copy the downloaded binaries and man pages into the container system from the verify stage.
+# Setuid on binaries with $USER rights, to limit root usage.
+COPY --from=verify /verify/dogecoin/share/man/man1/*.1 /usr/share/man/man1/
+
+COPY --from=verify --chown=${USER}:${USER} --chmod=4555 /verify/dogecoin/bin/dogecoin* /usr/local/bin/
+
+COPY --chmod=500 entrypoint.py /usr/local/bin/entrypoint.py
 
 # P2P network (mainnet, testnet & regnet respectively)
 EXPOSE 22556 44556 18444


### PR DESCRIPTION
refined Dockerfile by extracting the specific files we need from our archive and copying each while setting appropriate permissions and owner:group in each COPY.

amd64 63.36 MB
https://hub.docker.com/layers/182012868/xanimo/1.14.5-dogecoin/buildx-lean/images/sha256-02d46eed6bf4e35a21c7873b938a5be46d5526e895b21423a2d758213d24da89?context=repo

compared to current 91.02 MB
https://hub.docker.com/layers/180643304/xanimo/1.14.5-dogecoin/bullseye/images/sha256-df482148bac8ebe4861898b357d609533b4847e514d01bc76a7cdb2479c071ca?context=repo