### PR TITLE
security: apply least-privilege by removing chown on binaries

### DIFF
--- a/1.14.5/bullseye/Dockerfile
+++ b/1.14.5/bullseye/Dockerfile
@@ -74,7 +74,6 @@ COPY --from=verify /verify/dogecoin.tar.gz ./
 # Setuid on binaries with $USER rights, to limit root usage.
 RUN tar -xvf dogecoin.tar.gz --strip-components=1 \
     && cp bin/dogecoind bin/dogecoin-cli bin/dogecoin-tx /usr/local/bin/ \
-    && chown ${USER}:${USER} /usr/local/bin/dogecoin* \
     && chmod 4555 /usr/local/bin/dogecoin* \
     && rm -rf *
 


### PR DESCRIPTION
I was triggered by the test shown in #33 because `chown`ing files under /usr/local to be owned by a user is not a good practice.  

It is not needed for dogecoin:dogecoin to have permissions on binaries installed in /usr/local/bin because we allow anyone to
execute these anyway through the `chmod 4555`. All the `chown` directive really does is give running processes like dogecoind access to these files, which the process then can `chmod` and subsequently overwrite.

Instead, let root own the files, but keep allowing execution by anyone, which will disallow a process spawned by the dogecoin user to change these files - this reduces potential impact of future / unknown remote code execution vulnerabilities in Dogecoin Core.

Before this PR, a process running as `dogecoin:dogecoin` inside the container could for example perform the equivalent of `chmod 755 /usr/local/bin/dogecoin-cli && echo "#!/bin/bash\necho je suis un virus" > /usr/local/bin/dogecoin-cli`. After this PR, it cannot.