### PR TITLE
add CI test for files metadata

### DIFF
--- a/tests/integration/files_metadata.py
+++ b/tests/integration/files_metadata.py
@@ -1,0 +1,50 @@
+#!/usr/bin/env python3
+# Copyright (c) 2021 The Dogecoin Core developers
+"""
+    Tests metadatas of files provided by the Dockerfile.
+"""
+
+import os
+
+from .framework.test_runner import TestRunner
+
+class FilesMetadataTest(TestRunner):
+    """Verification of container files' metadata"""
+
+    def __init__(self):
+        TestRunner.__init__(self)
+
+    def add_options(self, parser):
+        """Extra options for the test"""
+
+    def run_test(self):
+        """
+        Verifiy availability and metadata of all files provided by the image,
+        check user, group and mode.
+        """
+        location = "/usr/local/bin/"
+
+        abs_path = lambda executable : os.path.join(location, executable)
+
+        dogecoind = self.container_file(abs_path("dogecoind"))
+        assert dogecoind.user == "dogecoin"
+        assert dogecoind.group == "dogecoin"
+        assert dogecoind.mode == "4555"
+
+        dogecointx = self.container_file(abs_path("dogecoin-tx"))
+        assert dogecointx.user == "dogecoin"
+        assert dogecointx.group == "dogecoin"
+        assert dogecointx.mode == "4555"
+
+        dogecoincli = self.container_file(abs_path("dogecoin-cli"))
+        assert dogecoincli.user == "dogecoin"
+        assert dogecoincli.group == "dogecoin"
+        assert dogecoincli.mode == "4555"
+
+        entrypoint = self.container_file(abs_path("entrypoint.py"))
+        assert entrypoint.user == "root"
+        assert entrypoint.group == "root"
+        assert entrypoint.mode == "500"
+
+if __name__ == '__main__':
+    FilesMetadataTest().main()

--- a/tests/integration/framework/container_file.py
+++ b/tests/integration/framework/container_file.py
@@ -1,0 +1,44 @@
+"""
+    Base class to store metadatas of container files.
+"""
+
+class ContainerFile:
+    """
+    File interface to inspects metadatas of container files.
+
+    Run shell command (self.command) and store container output.
+    """
+    command = "stat"
+    # format: <name> <user>:<group> <mode>
+    format = "%n %U:%G %a"
+
+    def __init__(self, name, container_cli):
+        self.name = name
+        self.user = None
+        self.group = None
+        self.mode = None
+
+        # Retrieve file information inside the container
+        file_info = container_cli([], self.shell_command())
+
+        # Convert raw container output to class attributes
+        self.convert_output(file_info.stdout.decode("utf-8"))
+
+    def shell_command(self):
+        """Format the container command to retrieve file metadata"""
+        return [self.command, self.name, "-c", self.format]
+
+    def convert_output(self, stat_output):
+        """
+        Clean up container output about file metadatas. Convert
+        informations into ContainerFile attributes.
+
+        Conversion follow self.format.
+        """
+        stat_output = stat_output.strip()
+        _, user_info, mode = stat_output.split(" ")
+        self.mode = mode
+        self.user, self.group = user_info.split(":")
+
+    def __str__(self):
+        return f"{self.name} {self.user}:{self.group} {self.mode}"

--- a/tests/integration/framework/test_runner.py
+++ b/tests/integration/framework/test_runner.py
@@ -8,6 +8,7 @@ import argparse
 import sys
 
 from .docker_runner import DockerRunner
+from .container_file import ContainerFile
 
 class TestConfigurationError(Exception):
     """Raised when the test is configured inconsistently"""
@@ -34,6 +35,10 @@ class TestRunner:
             self.options.image, self.options.verbose)
 
         return runner.run_interactive_command(envs, args)
+
+    def container_file(self, filename):
+        """Retrieve metadata related to a file inside containers"""
+        return ContainerFile(filename, container_cli=self.run_command)
 
     def main(self):
         """main loop"""

--- a/tests/integration_runner.py
+++ b/tests/integration_runner.py
@@ -41,6 +41,7 @@ class IntegrationRunner(TestRunner):
         #List of tests to run
         tests = [
             [ "version", [ "--version", self.options.version ] ],
+            [ "files_metadata", [] ],
         ]
 
         for test in tests:


### PR DESCRIPTION
Fix https://github.com/dogecoin/docker/issues/33

Convert tests + add a class to check files information inside containers.

## Run CI tests

Will need some documentation to facilitate usage, but for now it's possible to run it using:
```bash
python3 -m tests.integration_runner --platform amd64 --image [dogecoin-image] --version 1.14.5 [--verbose]
```