### PR TITLE
qa: fix ci on tests directory

### DIFF
--- a/.github/workflows/build-ci.yml
+++ b/.github/workflows/build-ci.yml
@@ -6,7 +6,7 @@ on:
       - "**/Dockerfile"
       - "**/entrypoint.py"
       - "**/PLATFORMS"
-      - "tests/"
+      - "tests/**"
       - "tools/genmatrix.js"
       - ".github/workflows/build-ci.yml"
 


### PR DESCRIPTION
CI tests are not launched when `tests` directory is edited. GitHub Action do not offer a syntax ending only with a slash.

See: https://docs.github.com/en/actions/learn-github-actions/workflow-syntax-for-github-actions#filter-pattern-cheat-sheet

Issue found with https://github.com/dogecoin/docker/pull/47, needed for this PR.