### PR TITLE
DockerRunner: Enable background container to run commands against

### DIFF
--- a/tests/integration/framework/docker_runner.py
+++ b/tests/integration/framework/docker_runner.py
@@ -80,7 +80,13 @@ class DockerRunner:
             command.append("-e")
             command.append(env)
 
-        command.append(self.container_id)
+        # Use container or image depending on command type
+        if docker_cmd == "exec":
+            tag = self.container_id
+        elif docker_cmd == "run":
+            tag = self.image
+
+        command.append(tag)
 
         # Launch all shell commands using entrypoint.py only
         command.append("entrypoint.py")

--- a/tests/integration/framework/docker_runner.py
+++ b/tests/integration/framework/docker_runner.py
@@ -34,9 +34,7 @@ class DockerRunner:
         return self._shell(command)
 
     def run(self, envs, args):
-        """
-        Launch `docker run` commands to create a new container for each command
-        """
+        """Launch `docker run` commands, create a new container each time"""
         command = self._construct_command("run", envs, args)
         return self._shell(command)
 

--- a/tests/integration/framework/docker_runner.py
+++ b/tests/integration/framework/docker_runner.py
@@ -50,7 +50,7 @@ class DockerRunner:
                 self.image,
                 "sleep", "infinity",
                 ]
-        self.container_id = self._shell(create_command, silent=True)
+        self.container_id = self._shell(create_command, silent=True)[:16]
 
     def _stop_background(self):
         """Remove background test container if used"""

--- a/tests/integration/framework/docker_runner.py
+++ b/tests/integration/framework/docker_runner.py
@@ -45,25 +45,14 @@ class DockerRunner:
         self._stop_background()
 
     def _start_background(self):
-        """
-        Launch a docker container. Done in 2 step using create + start.
-
-        Keep the container running with a shell open thanks to `--interactive`,
-        having stdin open keep the process running.
-        """
+        """Start a background container to run `exec` commands inside"""
         create_command = [
-                "docker", "create",
+                "docker", "run", "-d",
                 "--platform", self.platform,
-                "--interactive",
                 self.image,
-                "/bin/bash",
+                "sleep", "infinity",
                 ]
         self.container_id = self._shell(create_command, silent=True)
-
-        start_command = [
-                "docker", "start", self.container_id
-                ]
-        self._shell(start_command, silent=True)
 
     def _stop_background(self):
         """Remove background test container if used"""

--- a/tests/integration/framework/docker_runner.py
+++ b/tests/integration/framework/docker_runner.py
@@ -8,49 +8,83 @@ import subprocess
 import sys
 
 class DockerRunner:
-    """Run docker containers for testing"""
+    """Run a docker container in background to execute testing commands"""
 
     def __init__(self, platform, image, verbose):
         """Sets platform and image for all tests ran with this instance"""
         self.platform = platform
         self.image = image
         self.verbose = verbose
+        self.container_id = None
 
-    def construct_docker_command(self, envs, args):
+        # Launch the container
+        self._start()
+
+    def execute(self, envs, args):
         """
-        Construct a docker command with env and args
+        Run our target docker image with a list of
+        environment variables and a list of arguments
         """
-        command = ["docker", "run", "--platform", self.platform]
+        command = self._construct_command(envs, args)
+        return self._shell(command)
+
+    def __del__(self):
+        """Remove test container"""
+        stop_command = ["docker", "rm", "-f", self.container_id]
+        self._shell(stop_command, silent=True)
+
+    def _start(self):
+        """
+        Launch a docker container. Done in 2 step using create + start.
+
+        Keep the container running with a shell open thanks to `--interactive`,
+        having stdin open keep the process running.
+        """
+        create_command = [
+                "docker", "create",
+                "--platform", self.platform,
+                "--interactive",
+                self.image,
+                "/bin/bash",
+                ]
+        self.container_id = self._shell(create_command, silent=True)
+
+        start_command = [
+                "docker", "start", self.container_id
+                ]
+        self._shell(start_command, silent=True)
+
+    def _shell(self, command, silent=False):
+        """Run an arbitrary shell command and return its output"""
+        if self.verbose and not silent:
+            print(f"$ { ' '.join(command) }")
+
+        try:
+            result = subprocess.run(command, capture_output=True, check=True)
+        except subprocess.CalledProcessError as command_err:
+            print(command_err.stdout.decode("utf-8"), file=sys.stdout)
+            print(command_err.stderr.decode("utf-8"), file=sys.stderr)
+            raise command_err
+
+        return result.stdout.decode("utf-8").strip()
+
+    def _construct_command(self, envs, args):
+        """Construct a docker command with env and args"""
+        command = ["docker", "exec"]
 
         for env in envs:
             command.append("-e")
             command.append(env)
 
-        command.append(self.image)
+        command.append(self.container_id)
 
-        for arg in args:
-            command.append(arg)
+        # Launch all shell commands using entrypoint.py only
+        command.append("entrypoint.py")
+
+        # Need to add a default executables added by CMD normally
+        if len(args) == 0 or args[0].startswith("-"):
+            command.append("dogecoind")
+
+        command.extend(args)
 
         return command
-
-    def run_interactive_command(self, envs, args):
-        """
-        Run our target docker image with a list of
-        environment variables and a list of arguments
-        """
-        command = self.construct_docker_command(envs, args)
-
-        if self.verbose:
-            print(f"Running command: { ' '.join(command) }")
-
-        try:
-            output = subprocess.run(command, capture_output=True, check=True)
-        except subprocess.CalledProcessError as docker_err:
-            print(f"Error while running command: { ' '.join(command) }", file=sys.stderr)
-            print(docker_err, file=sys.stderr)
-            print(docker_err.stderr.decode("utf-8"), file=sys.stderr)
-            print(docker_err.stdout.decode("utf-8"), file=sys.stdout)
-
-            raise docker_err
-
-        return output

--- a/tests/integration/framework/docker_runner.py
+++ b/tests/integration/framework/docker_runner.py
@@ -82,19 +82,16 @@ class DockerRunner:
 
         # Use container or image depending on command type
         if docker_cmd == "exec":
-            tag = self.container_id
+            # Use entrypoint.py to enter `docker exec`
+            command.extend([self.container_id, "entrypoint.py"])
+
+            # Need to add the default executable added by CMD not given by
+            # exec, entrypoint will crash without CMD default argument.
+            if len(args) == 0 or args[0].startswith("-"):
+                command.append("dogecoind")
+
         elif docker_cmd == "run":
-            tag = self.image
-
-        command.append(tag)
-
-        # Launch all shell commands using entrypoint.py only
-        command.append("entrypoint.py")
-
-        # Need to add a default executables added by CMD normally
-        if len(args) == 0 or args[0].startswith("-"):
-            command.append("dogecoind")
+            command.extend(["--platform", self.platform, self.image])
 
         command.extend(args)
-
         return command

--- a/tests/integration/framework/docker_runner.py
+++ b/tests/integration/framework/docker_runner.py
@@ -21,11 +21,15 @@ class DockerRunner:
         self._start()
 
     def execute(self, envs, args):
+        """Launch `docker exec` commands inside the background container"""
+        command = self._construct_command("exec", envs, args)
+        return self._shell(command)
+
+    def run(self, envs, args):
         """
-        Run our target docker image with a list of
-        environment variables and a list of arguments
+        Launch `docker run` commands to create a new container for each command
         """
-        command = self._construct_command(envs, args)
+        command = self._construct_command("run", envs, args)
         return self._shell(command)
 
     def __del__(self):
@@ -68,9 +72,9 @@ class DockerRunner:
 
         return result.stdout.decode("utf-8").strip()
 
-    def _construct_command(self, envs, args):
+    def _construct_command(self, docker_cmd, envs, args):
         """Construct a docker command with env and args"""
-        command = ["docker", "exec"]
+        command = ["docker", docker_cmd]
 
         for env in envs:
             command.append("-e")

--- a/tests/integration/framework/test_runner.py
+++ b/tests/integration/framework/test_runner.py
@@ -16,7 +16,7 @@ class TestRunner:
     """Base class to define and run Dogecoin Core Docker tests with"""
     def __init__(self):
         self.options = {}
-        self.container = None
+        self.docker_cli = None
 
     def add_options(self, parser):
         """Allow adding options in tests"""
@@ -33,14 +33,14 @@ class TestRunner:
         assert self.options.platform is not None
         assert self.options.image is not None
 
-        return self.container.execute(envs, args)
+        return self.docker_cli.execute(envs, args)
 
     def docker_run(self, envs, args):
         """Launch `docker run` command, create a new container for each run"""
         assert self.options.platform is not None
         assert self.options.image is not None
 
-        return self.container.run(envs, args)
+        return self.docker_cli.run(envs, args)
 
     def main(self):
         """main loop"""
@@ -55,7 +55,7 @@ class TestRunner:
         self.add_options(parser)
         self.options = parser.parse_args()
 
-        self.container = DockerRunner(self.options.platform,
+        self.docker_cli = DockerRunner(self.options.platform,
                 self.options.image, self.options.verbose)
 
         self.run_test()

--- a/tests/integration/framework/test_runner.py
+++ b/tests/integration/framework/test_runner.py
@@ -15,8 +15,8 @@ class TestConfigurationError(Exception):
 class TestRunner:
     """Base class to define and run Dogecoin Core Docker tests with"""
     def __init__(self):
-        """Make sure there is an options object"""
         self.options = {}
+        self.container = None
 
     def add_options(self, parser):
         """Allow adding options in tests"""
@@ -30,10 +30,7 @@ class TestRunner:
         assert self.options.platform is not None
         assert self.options.image is not None
 
-        runner = DockerRunner(self.options.platform,
-            self.options.image, self.options.verbose)
-
-        return runner.run_interactive_command(envs, args)
+        return self.container.execute(envs, args)
 
     def main(self):
         """main loop"""
@@ -47,6 +44,9 @@ class TestRunner:
 
         self.add_options(parser)
         self.options = parser.parse_args()
+
+        self.container = DockerRunner(self.options.platform,
+                self.options.image, self.options.verbose)
 
         self.run_test()
         print("Tests successful")

--- a/tests/integration/framework/test_runner.py
+++ b/tests/integration/framework/test_runner.py
@@ -25,12 +25,22 @@ class TestRunner:
         """Actual test, must be implemented by the final class"""
         raise NotImplementedError
 
-    def run_command(self, envs, args):
-        """Run a docker command with env and args"""
+    def docker_exec(self, envs, args):
+        """
+        Launch `docker exec` command, run command inside a background container.
+        Let execute mutliple instructions in the same container.
+        """
         assert self.options.platform is not None
         assert self.options.image is not None
 
         return self.container.execute(envs, args)
+
+    def docker_run(self, envs, args):
+        """Launch `docker run` command, create a new container for each run"""
+        assert self.options.platform is not None
+        assert self.options.image is not None
+
+        return self.container.run(envs, args)
 
     def main(self):
         """main loop"""

--- a/tests/integration/version.py
+++ b/tests/integration/version.py
@@ -28,20 +28,20 @@ class VersionTest(TestRunner):
 
         # check dogecoind with only env
         dogecoind = self.run_command(["VERSION=1"], [])
-        self.ensure_version_on_first_line(dogecoind.stdout)
+        self.ensure_version_on_first_line(dogecoind)
 
         # check dogecoin-cli
         dogecoincli = self.run_command([], ["dogecoin-cli", "-?"])
-        self.ensure_version_on_first_line(dogecoincli.stdout)
+        self.ensure_version_on_first_line(dogecoincli)
 
         # check dogecoin-tx
         dogecointx = self.run_command([], ["dogecoin-tx", "-?"])
-        self.ensure_version_on_first_line(dogecointx.stdout)
+        self.ensure_version_on_first_line(dogecointx)
 
         # make sure that we find version errors
         caught_error = False
         try:
-            self.ensure_version_on_first_line("no version here".encode('utf-8'))
+            self.ensure_version_on_first_line("no version here")
         except AssertionError:
             caught_error = True
 
@@ -50,7 +50,7 @@ class VersionTest(TestRunner):
 
     def ensure_version_on_first_line(self, cmd_output):
         """Assert that the version is contained in the first line of output string"""
-        first_line = cmd_output.decode("utf-8").split("\n")[0]
+        first_line = cmd_output.split("\n")[0]
 
         if re.match(self.version_expr, first_line) is None:
             text = f"Could not find version { self.options.version } in { first_line }"

--- a/tests/integration/version.py
+++ b/tests/integration/version.py
@@ -27,15 +27,15 @@ class VersionTest(TestRunner):
         self.version_expr = re.compile(f".*{ self.options.version }.*")
 
         # check dogecoind with only env
-        dogecoind = self.run_command(["VERSION=1"], [])
+        dogecoind = self.docker_exec(["VERSION=1"], [])
         self.ensure_version_on_first_line(dogecoind)
 
         # check dogecoin-cli
-        dogecoincli = self.run_command([], ["dogecoin-cli", "-?"])
+        dogecoincli = self.docker_exec([], ["dogecoin-cli", "-?"])
         self.ensure_version_on_first_line(dogecoincli)
 
         # check dogecoin-tx
-        dogecointx = self.run_command([], ["dogecoin-tx", "-?"])
+        dogecointx = self.docker_exec([], ["dogecoin-tx", "-?"])
         self.ensure_version_on_first_line(dogecointx)
 
         # make sure that we find version errors

--- a/tests/integration/version.py
+++ b/tests/integration/version.py
@@ -27,15 +27,15 @@ class VersionTest(TestRunner):
         self.version_expr = re.compile(f".*{ self.options.version }.*")
 
         # check dogecoind with only env
-        dogecoind = self.docker_exec(["VERSION=1"], [])
+        dogecoind = self.docker_run(["VERSION=1"], [])
         self.ensure_version_on_first_line(dogecoind)
 
         # check dogecoin-cli
-        dogecoincli = self.docker_exec([], ["dogecoin-cli", "-?"])
+        dogecoincli = self.docker_run([], ["dogecoin-cli", "-?"])
         self.ensure_version_on_first_line(dogecoincli)
 
         # check dogecoin-tx
-        dogecointx = self.docker_exec([], ["dogecoin-tx", "-?"])
+        dogecointx = self.docker_run([], ["dogecoin-tx", "-?"])
         self.ensure_version_on_first_line(dogecointx)
 
         # make sure that we find version errors


### PR DESCRIPTION
Following a comment where @patricklodder was speaking about having a mechanism to start/stop a container for the entire test.

Implemented it in the idea to add some tests who can need it, at least datadir test from #50.

It changes the way commands are proceeded : A single background container is started for the entire test of a TestRunner subclass, and all commands for the test are executed with `docker exec` (calling the entrypoint directly).

## Run CI tests

Will need some documentation to facilitate usage, but for now it's possible to run it using:
```bash
python3 -m tests.integration_runner --platform amd64 --image [dogecoin-image] --version 1.14.5 [--verbose]
```