### PR TITLE
configure pylint for tests

### DIFF
--- a/.github/workflows/lint-py.yml
+++ b/.github/workflows/lint-py.yml
@@ -24,5 +24,11 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
 
-      - name: Run linter
-        run: find . -name "*.py" | xargs pylint
+      - name: Run linter for images code
+        run: find . -name "*.py" ! -path "*/tests/*" | xargs pylint
+
+      - name: Install pylint dependencies for tests
+        run: pip3 install pytest
+
+      - name: Run linter for tests code
+        run: find "./tests" -name "*.py" | xargs pylint --rcfile=pylintrc.tests

--- a/pylintrc.tests
+++ b/pylintrc.tests
@@ -1,0 +1,7 @@
+[entrypoint-tests]
+disable =   duplicate-code, # Tests having similar code
+            no-member,      # pytest global variables in conftest.py not detected
+            consider-using-with, # conftest temporary directory would need a with
+            import-error    # EntrypointHook unable to import entrypoint
+    
+    

--- a/pylintrc.tests
+++ b/pylintrc.tests
@@ -1,4 +1,4 @@
-[entrypoint-tests]
+[tests-configuration]
 disable =   duplicate-code, # Tests having similar code
             no-member,      # pytest global variables in conftest.py not detected
             consider-using-with, # conftest temporary directory would need a with


### PR DESCRIPTION
Prepare pylint configuration for tests from #25. Linter is done in 2 times, once for the source code of images without any `pylintrc`, and then for tests which have more trouble for linters.